### PR TITLE
update readme to point to expo/expo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
-<div align="center">
-  <h1>expo-test-runner</h1>
-  <p></p>
-  <p>Script that enchants your test experience!</p>
-  <sup>
-    <a href="https://www.npmjs.com/package/expo-test-runner">
-      <img src="https://img.shields.io/npm/v/expo-test-runner?style=flat-square" alt="releases" />
-    </a>
-    <a href="https://github.com/expo/expo-test-runner/blob/main/LICENSE.md">
-      <img src="https://img.shields.io/github/license/expo/expo-test-runner?style=flat-square" alt="license" />
-    </a>
-  </sup>
-  <br />
+# expo-test-runner
 
-  <br />
-</div>
+> DEPRECATED: This repo is deprecated, as the package has moved to the [**`expo/expo`**](https://github.com/expo/expo/tree/main/packages/expo-test-runner) repo.
+
+Script that enchants your test experience!
+
+<sup>
+  <a href="https://www.npmjs.com/package/expo-test-runner">
+    <img src="https://img.shields.io/npm/v/expo-test-runner?style=flat-square" alt="releases" />
+  </a>
+  <a href="https://github.com/expo/expo-test-runner/blob/main/LICENSE.md">
+    <img src="https://img.shields.io/github/license/expo/expo-test-runner?style=flat-square" alt="license" />
+  </a>
+</sup>


### PR DESCRIPTION
Now that the package has moved to expo/expo, update the README to point there and say that this repo is deprecated.